### PR TITLE
SortingQueueItems killed

### DIFF
--- a/src/Dossier.js
+++ b/src/Dossier.js
@@ -8,7 +8,16 @@
  */
 
 
-var _DossierJS = function(window, $, undefined) {
+(function (factory, root) {
+
+    if(typeof define === "function" && define.amd) {
+        define("DossierJS", ["jquery"], function($) {
+            return factory(root, $);
+        });
+    } else
+        window.DossierJS = factory(root, $);
+
+})(function (window, $, undefined) {
     /* Constants */
     var API_VERSION = {
         dossier: 1
@@ -955,15 +964,8 @@ var _DossierJS = function(window, $, undefined) {
         Folder: Folder,
         Subfolder: Subfolder
     };
-};
 
-if(typeof define === "function" && define.amd) {
-    define("DossierJS", ["jquery"], function($) {
-        return _DossierJS(window, $);
-    });
-} else {
-    window.DossierJS = _DossierJS(window, $);
-}
+}, window);
 
 
 /*  Emacs settings     */

--- a/src/Dossier.js
+++ b/src/Dossier.js
@@ -837,7 +837,7 @@ var _DossierJS = function(window, $, undefined) {
 
             /* Add base64-encoded username and password to appropriate header. */
             options.headers.Authorization = "Basic "
-                + btoa(this.username + ":" + this.password);
+                + window.btoa(this.username + ":" + this.password);
         }
 
         return this.add_(

--- a/src/Dossier.js
+++ b/src/Dossier.js
@@ -1,6 +1,6 @@
 /** Dossier.js --- Diffeo's dossier.web API
  *
- * Copyright (C) 2014 Diffeo
+ * Copyright (C) 2014, 2015 Diffeo
  *
  * Comments:
  *

--- a/src/Dossier.js
+++ b/src/Dossier.js
@@ -792,129 +792,6 @@ var _DossierJS = function(window, $, undefined) {
         }
     }
 
-    // SortingQueueItems provides SortingQueue integration with DossierJS.
-    // Namely, it provides the following callback functions:
-    //
-    //   moreTexts - Returns results from a search.
-    //   itemDismissed - Adds a label between the `query_content_id` and
-    //                   the text item that was dismissed. The coref value
-    //                   used is `-1`.
-    //
-    // An instance of `SortingQueueItems` can be used to initialize an
-    // instance of `SortingQueue` with the appropriate callbacks. e.g.,
-    //
-    //   var qitems = new SortingQueueItems(...);
-    //   new SortingQueue.Sorter(
-    //     config, $.extend(qitems.callbacks(), yourCallbacks));
-    //
-    // The query and search engine can be changed by modifying the contents
-    // of the `query_content_id` and `engine_name` instance attributes,
-    // respectively. When an attribute is modified, no changes will occur
-    // visually. To cause the queue to be refreshed with the new settings,
-    // you can forcefully empty it, which will cause SortingQueue to refill
-    // it with the new settings:
-    //
-    //   qitems.engine_name = '<engine name>';
-    //   qitems.query_content_id = '<content id>';
-    //   sorting_desk_instance.items.removeAll();
-    //
-    // There are a number of attributes that can be set on an instance of
-    // `SortingQueueItems` that affect search engine behavior:
-    //
-    //   annotator   - Used whenever a label is created.
-    //   limit       - Limits the number of results returned to the user.
-    //                 Defaults to `5`.
-    //   query_subtopic_id - Causes a search engine to use subtopic querying.
-    //                       This only works if the search engine supports it!
-    //   params      - Pass arbitrary query parameters to the search engine.
-    //
-    // The `api` parameter should be an instance of `DossierJS.API`.
-    //
-    // Each instance of `SortingQueueItems` may be used with precisely
-    // one instance of `SortingQueue`.
-    var SortingQueueItems = function(api, engine_name, query_content_id,
-                                     annotator) {
-        this.api = api;
-        this.engine_name = engine_name;
-        this.query_content_id = query_content_id;
-        this.query_subtopic_id = null;
-        this.annotator = annotator;
-        this.limit = 5;
-        this.params = {};
-        this._processing = false;
-    };
-
-    // Returns an object of callbacks that may be given directly to the
-    // `SortingQueue` constructor.
-    SortingQueueItems.prototype.callbacks = function() {
-        return {
-            itemDismissed:
-                SortingQueueItems.prototype._itemDismissed.bind(this),
-            moreTexts: SortingQueueItems.prototype._moreTexts.bind(this)
-        };
-    };
-
-    // This is just like `DossierJS.API.addLabel`, except it fixes one of
-    // the content ids to the current value of
-    // `SortingQueueItems.query_content_id`, and it fixes the value of
-    // `annotator` to `SortingQueueItems.annotator`.
-    //
-    // (It returns the jQuery promise returned by `DossierJS.API.addLabel`.)
-    SortingQueueItems.prototype.addLabel = function(cid, coref_value) {
-        return this.api.addLabel(this.query_content_id,
-                                 cid, this.annotator, coref_value);
-    };
-
-    SortingQueueItems.prototype._itemDismissed = function(cobj) {
-        this.addLabel(cobj.content_id, COREF_VALUE_NEGATIVE);
-    };
-
-    SortingQueueItems.prototype._moreTexts = function() {
-        var self = this;
-
-        if (self._processing || !self.query_content_id) {
-            var deferred = $.Deferred();
-
-            window.setTimeout(function () {
-                if(self._processing) {
-                    console.warn('moreTexts in progress; ignoring');
-                    deferred.reject( { error: "Request in progress" } );
-                } else {
-                    console.error('Query content id not yet set');
-                    deferred.reject( { error: "No query content id" } );
-                }
-            } );
-
-            return deferred.promise();
-        }
-
-        self._processing = true;
-
-        var p = $.extend({limit: self.limit.toString()}, self.params);
-        if (self.query_subtopic_id !== null) {
-            p['subtopic_id'] = self.query_subtopic_id;
-        }
-        return self.api.search(self.engine_name, self.query_content_id, p)
-            .then(function(data) {
-                var items = [];
-                data.results.forEach(function(cobj) {
-                    items.push($.extend(cobj, {
-                        node_id: cobj.content_id,
-                        name: cobj.fc.value('NAME') || '',
-                        text: cobj.fc.value('sentences')
-                              || (cobj.fc.value('NAME') + ' (profile)'),
-                        url: cobj.fc.value('abs_url')
-                    }));
-                });
-                return items;
-            })
-            .always(function() {
-                self._processing = false;
-            })
-            .fail(function() {
-                console.error("moreTexts: request failed");
-            });
-    };
 
     /**
      * @class
@@ -1075,7 +952,6 @@ var _DossierJS = function(window, $, undefined) {
         FeatureCollection: FeatureCollection,
         Label: Label,
         LabelFetcher: LabelFetcher,
-        SortingQueueItems: SortingQueueItems,
         Folder: Folder,
         Subfolder: Subfolder
     };


### PR DESCRIPTION
This commit-set introduces a few minor (mostly) stylistic improvements and finally removes the `SortingQueueItems` class.