### PR TITLE
Authentication support for PollingRequest-derived classes

### DIFF
--- a/src/Dossier.js
+++ b/src/Dossier.js
@@ -882,12 +882,13 @@
     /**
      * @class
      * */
-    var PollingRequest = function (api, url, prefix)
+    var PollingRequest = function (api, url, prefix, auth)
     {
         this.api = api;
         this.url = url;
         this.prefix = prefix + ".";
-        this.xhr = { };
+        this.xhr = {};
+        this.auth = auth || null;
     };
 
     PollingRequest.prototype.post = function ()
@@ -912,15 +913,23 @@
     {
         if(this.xhr[req]) throw "Already processing: " + req.toUpperCase();
 
-        var self = this;
-        return this.xhr[req] = this.api.xhr.ajax(this.prefix + req, {
+        var opts = {
             type: req.toUpperCase(),
             url: this.url
-        } ).fail(function () {
-            console.error("Request %s failed [%s]",
-                          req.toUpperCase(),
-                          this.url);
-        } ).always(function () { self.xhr[req] = null; } );
+        };
+
+        if(this.auth) {
+            opts.username = this.auth.username;
+            opts.password = this.auth.password;
+        }
+
+        var self = this;
+        return this.xhr[req] = this.api.xhr.ajax(this.prefix + req, opts)
+            .fail(function () {
+                console.error("Request %s failed [%s]",
+                              req.toUpperCase(),
+                              this.url);
+            } ).always(function () { self.xhr[req] = null; } );
     };
 
 
@@ -950,13 +959,14 @@
     /**
      * @class
      * */
-    var Dragnet = function (api)
+    var Dragnet = function (api, auth)
     {
         PollingRequest.call(
             this,
             api,
             api.url("dragnet"),
-            "DN"
+            "DN",
+            auth
         );
     };
 


### PR DESCRIPTION
Allows `Dragnet` calls, and any `PollingRequest`-derived classes, to include authentication information.